### PR TITLE
Use monit description

### DIFF
--- a/pagerduty-resolve
+++ b/pagerduty-resolve
@@ -14,10 +14,7 @@ if [ -s $CONFIG_FILE ]; then
   . /etc/pagerduty/pagerduty.conf
 fi
 
-if [ -z "$1" ]; then
-  echo "Usage: $0 <event>"
-  exit 1
-elif [ -z "$PAGERDUTY_SERVICE_KEY" ]; then
+if [ -z "$PAGERDUTY_SERVICE_KEY" ]; then
   echo "Failed to resolve event: you must set the PAGERDUTY_SERVICE_KEY variable."
   exit 1
 elif [ ! -x "/usr/local/bin/pagerduty" ]; then
@@ -25,7 +22,12 @@ elif [ ! -x "/usr/local/bin/pagerduty" ]; then
   exit 1
 fi
 
-EVENT=$1
+if [ -z "$1" ]; then
+  EVENT="${MONIT_SERVICE} ${MONIT_DESCRIPTION}"
+else
+  EVENT="$1"
+fi
+
 HOST=`hostname -s`
 INCIDENT_KEY=`echo "$HOST:$EVENT" | md5sum | cut -f 1 -d ' '`
 TMP_FILE="/tmp/pagerduty-$INCIDENT_KEY"

--- a/pagerduty-trigger
+++ b/pagerduty-trigger
@@ -10,21 +10,23 @@
 # PAGERDUTY_SERVICE_KEY="1234567890abcdef1234567890abcdef"
 
 CONFIG_FILE=/etc/pagerduty/pagerduty.conf
-EVENT=${MONIT_DESCRIPTION-$1}
 
 if [ -s $CONFIG_FILE ]; then
   . /etc/pagerduty/pagerduty.conf
 fi
 
-if [ -z "$EVENT" ]; then
-  echo "Usage: $0 <event>"
-  exit 1
-elif [ -z "$PAGERDUTY_SERVICE_KEY" ]; then
+if [ -z "$PAGERDUTY_SERVICE_KEY" ]; then
   echo "Failed to trigger event: you must set the PAGERDUTY_SERVICE_KEY variable."
   exit 1
 elif [ ! -x "/usr/local/bin/pagerduty" ]; then
   echo "Failed to trigger event: /usr/local/bin/pagerduty does not exist or is not executable."
   exit 1
+fi
+
+if [ -z "$1" ]; then
+  EVENT="${MONIT_SERVICE} ${MONIT_DESCRIPTION}"
+else
+  EVENT="$1"
 fi
 
 HOST=`hostname -s`

--- a/pagerduty-trigger
+++ b/pagerduty-trigger
@@ -43,7 +43,7 @@ if [ -f "$TMP_FILE" ]; then
   fi
 fi
 
-DESCRIPTION="$EVENT failed on $HOST"
+DESCRIPTION="$EVENT on $HOST"
 DATE=`date`
 
 echo "$DATE: $DESCRIPTION" >> $TMP_FILE

--- a/pagerduty-trigger
+++ b/pagerduty-trigger
@@ -10,12 +10,13 @@
 # PAGERDUTY_SERVICE_KEY="1234567890abcdef1234567890abcdef"
 
 CONFIG_FILE=/etc/pagerduty/pagerduty.conf
+EVENT=${MONIT_DESCRIPTION-$1}
 
 if [ -s $CONFIG_FILE ]; then
   . /etc/pagerduty/pagerduty.conf
 fi
 
-if [ -z "$1" ]; then
+if [ -z "$EVENT" ]; then
   echo "Usage: $0 <event>"
   exit 1
 elif [ -z "$PAGERDUTY_SERVICE_KEY" ]; then
@@ -26,7 +27,6 @@ elif [ ! -x "/usr/local/bin/pagerduty" ]; then
   exit 1
 fi
 
-EVENT="$1"
 HOST=`hostname -s`
 INCIDENT_KEY=`echo "$HOST:$EVENT" | md5sum | cut -f 1 -d ' '`
 TMP_FILE="/tmp/pagerduty-$INCIDENT_KEY"


### PR DESCRIPTION
Taking on the work from https://github.com/pinterest/pagerduty-monit/pull/3, pull in monit env variables to populate the EVENT description and tidy it up a bit.
